### PR TITLE
Fixed directory names (convert vs creation) and copying of .bash_aliases

### DIFF
--- a/convert.sh
+++ b/convert.sh
@@ -30,6 +30,7 @@ chmod +x ~/convert/rhino-deinst/rhino-deinst
 mv ~/convert/rhino-deinst/rhino-deinst /usr/bin
 # Update the default mirrors
 source ~/.sources.sh
+rm ~/.sources.sh
 cd ~
 rm -rf ~/convert
 # Tell the user that the script has completed

--- a/convert.sh
+++ b/convert.sh
@@ -10,7 +10,7 @@ sudo apt-get autoremove -y
 # Move all required assets to the correct directories
 mv ~/convert/assets/rolling_rhino.png /usr/share/backgrounds
 mv ~/convert/assets/rolling_rhino-dark.png /usr/share/backgrounds
-mv ~/convert/assets/.bash_aliases /etc/skel
+cp ~/convert/assets/.bash_aliases /etc/skel
 rm -rf ~/.bash_aliases 
 rm -rf ~/.bashrc
 mv ~/convert/assets/.bash_aliases ~

--- a/convert.sh
+++ b/convert.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
+set -e
+
 mkdir -p ~/convert/assets && cd ~/convert || exit
-git clone https://github.com/rollingrhinoremix/assets ~/creation/assets
+git clone https://github.com/rollingrhinoremix/assets ~/convert/assets
 sudo apt-get update
 sudo apt-get upgrade -y
 sudo apt-get autoremove -y
@@ -15,17 +17,21 @@ mv ~/convert/assets/.bash_aliases ~
 mv ~/convert/assets/.bashrc ~
 mv ~/convert/assets/.sources.sh ~
 # Install rhino-config onto system 
-mkdir ~/creation/rhino-config
-cd ~/creation/rhino-config
+mkdir ~/convert/rhino-config
+cd ~/convert/rhino-config
 wget -q https://github.com/rollingrhinoremix/rhino-config/releases/latest/download/rhino-config
-chmod +x ~/creation/rhino-config/rhino-config
-mv ~/creation/rhino-config/rhino-config /usr/bin
+chmod +x ~/convert/rhino-config/rhino-config
+mv ~/convert/rhino-config/rhino-config /usr/bin
 # Install rhino-deinst onto system
-mkdir ~/creation/rhino-deinst
-cd ~/creation/rhino-deinst
+mkdir ~/convert/rhino-deinst
+cd ~/convert/rhino-deinst
 wget -q https://github.com/rollingrhinoremix/rhino-deinst/releases/latest/download/rhino-deinst
-chmod +x ~/creation/rhino-deinst/rhino-deinst
-mv ~/creation/rhino-deinst/rhino-deinst /usr/bin
+chmod +x ~/convert/rhino-deinst/rhino-deinst
+mv ~/convert/rhino-deinst/rhino-deinst /usr/bin
+# Update the default mirrors
+source ~/.sources.sh
+cd ~
+rm -rf ~/convert
 # Tell the user that the script has completed
 echo "---
 The conversion script has successfully completed. You are now running Rolling Rhino Remix


### PR DESCRIPTION
The following changes are proposed:

  * Several directory names started with `creation` but should instead be `convert`
  * Using `set -e` so that convert fails if any errors occur rather than continuing
  * Automatically updated the mirrors and removed `.sources.sh`
  * Proper copying of `.bash_aliases`

FYI: These change will help support the automated building of Rolling Rhino using mkosi.